### PR TITLE
fix: logic for hiding strings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17067,7 +17067,6 @@ const files_1 = __nccwpck_require__(6455);
 const strings_1 = __nccwpck_require__(8927);
 const labelNames = [
     "new",
-    `""`,
     "player",
     "kid",
     "mom",
@@ -17108,11 +17107,14 @@ const hideRenpyStrings = (projectId) => __awaiter(void 0, void 0, void 0, functi
         }
         let prevStringHidden = false;
         for (const string of fileStrings) {
-            if (string.data.text.startsWith("translate") ||
-                string.data.text.startsWith("old") ||
-                string.data.text.startsWith("#") ||
+            const trimText = string.data.text.trim();
+            const quoteRegex = /^['"]/;
+            if (trimText.startsWith("translate") ||
+                trimText.startsWith("old") ||
+                trimText.startsWith("#") ||
                 (prevStringHidden &&
-                    labelNames.every((label) => !string.data.text.startsWith(label)))) {
+                    labelNames.every((label) => !string.data.text.startsWith(label)) &&
+                    !quoteRegex.test(trimText))) {
                 prevStringHidden = true;
                 if (string.data.isHidden) {
                     console.log(`string already hidden: ${string.data.text}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17113,7 +17113,7 @@ const hideRenpyStrings = (projectId) => __awaiter(void 0, void 0, void 0, functi
                 trimText.startsWith("old") ||
                 trimText.startsWith("#") ||
                 (prevStringHidden &&
-                    labelNames.every((label) => !string.data.text.startsWith(label)) &&
+                    labelNames.every((label) => !trimText.startsWith(label)) &&
                     !quoteRegex.test(trimText))) {
                 prevStringHidden = true;
                 if (string.data.isHidden) {

--- a/src/plugins/hide-renpy-strings.ts
+++ b/src/plugins/hide-renpy-strings.ts
@@ -3,7 +3,6 @@ import { CrowdinStringHelper } from "../utils/strings";
 
 const labelNames = [
   "new",
-  `""`,
   "player",
   "kid",
   "mom",
@@ -48,12 +47,15 @@ export const hideRenpyStrings = async (projectId: number) => {
     }
     let prevStringHidden = false;
     for (const string of fileStrings) {
+      const trimText = string.data.text.trim();
+      const quoteRegex = /^['"]/;
       if (
-        string.data.text.startsWith("translate") ||
-        string.data.text.startsWith("old") ||
-        string.data.text.startsWith("#") ||
+        trimText.startsWith("translate") ||
+        trimText.startsWith("old") ||
+        trimText.startsWith("#") ||
         (prevStringHidden &&
-          labelNames.every((label) => !string.data.text.startsWith(label)))
+          labelNames.every((label) => !string.data.text.startsWith(label)) &&
+          !quoteRegex.test(trimText))
       ) {
         prevStringHidden = true;
         if (string.data.isHidden) {

--- a/src/plugins/hide-renpy-strings.ts
+++ b/src/plugins/hide-renpy-strings.ts
@@ -54,7 +54,7 @@ export const hideRenpyStrings = async (projectId: number) => {
         trimText.startsWith("old") ||
         trimText.startsWith("#") ||
         (prevStringHidden &&
-          labelNames.every((label) => !string.data.text.startsWith(label)) &&
+          labelNames.every((label) => !trimText.startsWith(label)) &&
           !quoteRegex.test(trimText))
       ) {
         prevStringHidden = true;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Believe this solves the issue with the few strings that were not hidden/visible correctly.

- The `TODO` string is returned from crowdin with a space before the `#`, so it wasn't matching the startsWith logic. Updated the plugin to trim the string before testing.
- The `""` label was incorrect - additionally, Crowdin seems to send them back with single quotes sometimes. Now implemented a RegEx test to see if the string starts with either a single or double quotation mark.