### PR TITLE
fix: hide notes header

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17717,6 +17717,7 @@ const isReservedHeading = (context, str) => {
         "text",
         "video-solution",
         "tests",
+        "notes",
     ];
     const captureGroupString = `(${reservedHeadings.join("|")})`;
     const regex = new RegExp(`--${captureGroupString}--`);

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -22,6 +22,7 @@ const isReservedHeading = (context: string, str: string) => {
     "text",
     "video-solution",
     "tests",
+    "notes",
   ];
   const captureGroupString = `(${reservedHeadings.join("|")})`;
   const regex = new RegExp(`--${captureGroupString}--`);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/45110

<!-- Feel free to add any additional description of changes below this line -->
Auto-hide the `# --notes--` header present in the RDB project files.