### PR TITLE
fix: make the directories variable an array

### DIFF
--- a/src/plugins/convert-chinese.ts
+++ b/src/plugins/convert-chinese.ts
@@ -23,7 +23,7 @@ const getFiles = async (directory: string, fileList: string[] = []) => {
  *
  * @param {string[]} directories The directory to convert.
  */
-export const convertChinese = async (directories: string) => {
+export const convertChinese = async (directories: string[]) => {
   console.info("Getting file list...");
   for (const directory of directories) {
     const files = await getFiles(join(process.cwd(), directory));


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I noticed in the JSDocs that it was intended to be an array, and wasn't actually one. It also made more sense than trying to iterate over a string and getting characters back. 