### PR TITLE
fix: lowercase directories, not files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40592,8 +40592,10 @@ function lowerCaseSubDirectories(dir) {
             if (file.isDirectory()) {
                 const filePath = (0, path_1.join)(dir, file.name);
                 const newFilePath = (0, path_1.join)(dir, file.name.toLowerCase());
-                console.log(`Renaming directory ${filePath} to ${newFilePath}`);
-                yield (0, promises_1.rename)(filePath, newFilePath);
+                if (filePath !== newFilePath) {
+                    console.log(`Renaming directory ${filePath} to ${newFilePath}`);
+                    yield (0, promises_1.rename)(filePath, newFilePath);
+                }
                 yield lowerCaseSubDirectories(newFilePath);
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -40584,49 +40584,28 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.lowercaseDirectories = void 0;
 const promises_1 = __nccwpck_require__(3292);
 const path_1 = __nccwpck_require__(1017);
-function readAllFiles(dir) {
+// Recursive function to process directories and subdirectories
+function lowerCaseSubDirectories(dir) {
     return __awaiter(this, void 0, void 0, function* () {
         const files = yield (0, promises_1.readdir)(dir, { withFileTypes: true });
-        let allFiles = [];
         for (const file of files) {
-            const filePath = (0, path_1.join)(dir, file.name);
             if (file.isDirectory()) {
-                const subFiles = yield readAllFiles(filePath);
-                allFiles = allFiles.concat(subFiles);
-            }
-            else {
-                allFiles.push(filePath);
+                const filePath = (0, path_1.join)(dir, file.name);
+                const newFilePath = (0, path_1.join)(dir, file.name.toLowerCase());
+                console.log(`Renaming directory ${filePath} to ${newFilePath}`);
+                yield (0, promises_1.rename)(filePath, newFilePath);
+                yield lowerCaseSubDirectories(newFilePath);
             }
         }
-        return allFiles;
     });
 }
-// Recursive function to process directories and subdirectories
-const processDirectory = (dirPath) => __awaiter(void 0, void 0, void 0, function* () {
-    // Get all files recursively
-    const allFiles = yield readAllFiles(dirPath);
-    // Lowercase directory names
-    for (const filePath of allFiles) {
-        const dirPath = filePath.split("/").slice(0, -1).join("/");
-        const dirName = filePath.split("/").pop();
-        const lowercasedDirName = dirName === null || dirName === void 0 ? void 0 : dirName.toLowerCase();
-        if (lowercasedDirName === undefined) {
-            throw new Error("Lowercased DirName Required");
-        }
-        if (lowercasedDirName !== dirName) {
-            const newPath = (0, path_1.join)(dirPath, lowercasedDirName);
-            console.log(`Renaming directory ${filePath} to ${newPath}`);
-            yield (0, promises_1.rename)(filePath, newPath);
-        }
-    }
-});
 /**
  *
  * @param {string} directory The directory tree that must be sorted through.
  */
 const lowercaseDirectories = (directory) => {
     console.info("Getting directory list...");
-    processDirectory(directory);
+    lowerCaseSubDirectories(directory);
 };
 exports.lowercaseDirectories = lowercaseDirectories;
 

--- a/src/plugins/lowercase-directories.ts
+++ b/src/plugins/lowercase-directories.ts
@@ -10,8 +10,10 @@ async function lowerCaseSubDirectories(dir: string): Promise<void> {
       const filePath = join(dir, file.name);
       const newFilePath = join(dir, file.name.toLowerCase());
 
-      console.log(`Renaming directory ${filePath} to ${newFilePath}`);
-      await rename(filePath, newFilePath);
+      if (filePath !== newFilePath) {
+        console.log(`Renaming directory ${filePath} to ${newFilePath}`);
+        await rename(filePath, newFilePath);
+      }
       await lowerCaseSubDirectories(newFilePath);
     }
   }

--- a/src/plugins/lowercase-directories.ts
+++ b/src/plugins/lowercase-directories.ts
@@ -2,42 +2,20 @@ import { Dirent } from "fs";
 import { readdir, rename } from "fs/promises";
 import { join } from "path";
 
-async function readAllFiles(dir: string): Promise<string[]> {
-  const files: Dirent[] = await readdir(dir, { withFileTypes: true });
-  let allFiles: string[] = [];
-  for (const file of files) {
-    const filePath = join(dir, file.name);
-    if (file.isDirectory()) {
-      const subFiles = await readAllFiles(filePath);
-      allFiles = allFiles.concat(subFiles);
-    } else {
-      allFiles.push(filePath);
-    }
-  }
-  return allFiles;
-}
-
 // Recursive function to process directories and subdirectories
-const processDirectory = async (dirPath: string) => {
-  // Get all files recursively
-  const allFiles = await readAllFiles(dirPath);
+async function lowerCaseSubDirectories(dir: string): Promise<void> {
+  const files: Dirent[] = await readdir(dir, { withFileTypes: true });
+  for (const file of files) {
+    if (file.isDirectory()) {
+      const filePath = join(dir, file.name);
+      const newFilePath = join(dir, file.name.toLowerCase());
 
-  // Lowercase directory names
-  for (const filePath of allFiles) {
-    const dirPath = filePath.split("/").slice(0, -1).join("/");
-    const dirName = filePath.split("/").pop();
-    const lowercasedDirName = dirName?.toLowerCase();
-    if (lowercasedDirName === undefined) {
-      throw new Error("Lowercased DirName Required");
-    }
-
-    if (lowercasedDirName !== dirName) {
-      const newPath = join(dirPath, lowercasedDirName);
-      console.log(`Renaming directory ${filePath} to ${newPath}`);
-      await rename(filePath, newPath);
+      console.log(`Renaming directory ${filePath} to ${newFilePath}`);
+      await rename(filePath, newFilePath);
+      await lowerCaseSubDirectories(newFilePath);
     }
   }
-};
+}
 
 /**
  *
@@ -45,5 +23,5 @@ const processDirectory = async (dirPath: string) => {
  */
 export const lowercaseDirectories = (directory: string) => {
   console.info("Getting directory list...");
-  processDirectory(directory);
+  lowerCaseSubDirectories(directory);
 };


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

As written the plugin was making files lowercase and ignoring directories.

Also life gets a little simpler if you update the directories as you recurse, rather than gathering them all and lowercasing. Reason being, if you have a nested directories, then you have to have rename the children first. If you rename as you descend into the tree, this problem goes away.

<!-- Feel free to add any additional description of changes below this line -->
