### PR TITLE
fix: use new curriculum paths

### DIFF
--- a/dist/configs/curriculum.yml
+++ b/dist/configs/curriculum.yml
@@ -8,13 +8,13 @@
 files:
   [
     {
-      "source": "/curriculum/challenges/english/**/*.md",
-      "translation": "/curriculum/challenges/%language%/**/%original_file_name%",
+      "source": "/curriculum/challenges/english/blocks/**/*.md",
+      "translation": "/curriculum/challenges/%language%/blocks/**/%original_file_name%",
       "type": "fm_md",
     },
     {
-      "source": "/curriculum/challenges/english/00-certifications/**/*.yml",
-      "translation": "/curriculum/challenges/%language%/00-certifications/**/%original_file_name%",
+      "source": "/curriculum/challenges/english/certifications/*.yml",
+      "translation": "/curriculum/challenges/%language%/certifications/%original_file_name%",
     },
     {
       "source": "/curriculum/dictionaries/english/comments.json",

--- a/src/configs/curriculum.yml
+++ b/src/configs/curriculum.yml
@@ -8,13 +8,13 @@
 files:
   [
     {
-      "source": "/curriculum/challenges/english/**/*.md",
-      "translation": "/curriculum/challenges/%language%/**/%original_file_name%",
+      "source": "/curriculum/challenges/english/blocks/**/*.md",
+      "translation": "/curriculum/challenges/%language%/blocks/**/%original_file_name%",
       "type": "fm_md",
     },
     {
-      "source": "/curriculum/challenges/english/00-certifications/**/*.yml",
-      "translation": "/curriculum/challenges/%language%/00-certifications/**/%original_file_name%",
+      "source": "/curriculum/challenges/english/certifications/*.yml",
+      "translation": "/curriculum/challenges/%language%/certifications/%original_file_name%",
     },
     {
       "source": "/curriculum/dictionaries/english/comments.json",


### PR DESCRIPTION
Attempt to fix the broken curriculum uploads and downloads. I think this will do it.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
